### PR TITLE
Add skills sorter to top of project list

### DIFF
--- a/src/Home/projects.tsx
+++ b/src/Home/projects.tsx
@@ -6,6 +6,11 @@ type ProjectT = {
 
 export const projects: ProjectT[] = [
   {
+    title: "Skills Sorter",
+    description: "A card-sorting task to group professional skills",
+    link: "https://skills.whoisnaz.com",
+  },
+  {
     title: "Edinburgh Dog Network",
     description: "A community-driven network analysis of the dogs in Edinburgh",
     link: "https://graphcommons.com/graphs/4d5d4d8c-f0b6-40fa-be77-c8544d97076c",


### PR DESCRIPTION
## Summary
- rename skills site to **Skills Sorter**
- move Skills Sorter to the beginning of the projects list

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686e792693e883318a5913d0246424cc